### PR TITLE
Alterar a máscara da data de crédito do header

### DIFF
--- a/config/bradesco/cnab400/cobranca.yml
+++ b/config/bradesco/cnab400/cobranca.yml
@@ -525,7 +525,7 @@ retorno:
       default: ''
     data_credito:
       pos: [380,385]
-      picture: '9(6)'
+      picture: 'X(6)'
     brancos_02:
       pos: [386,394]
       picture: 'X(9)'


### PR DESCRIPTION
O valor do campo não pode ser numérico. 
Ex: a data 090517, por ser um valor numérico, seria convertida para 90517. 
Na criação de um objeto DateTime a partir do formato dmy, seria criado um objeto com a data 09/05/2011 e o esperado é 09/05/2017